### PR TITLE
Make GH_TOKEN optional for gh-pages plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ gh-pages publishing plugin for [semantic-release](https://github.com/semantic-re
 
 | Step               | Description |
 |--------------------|-------------|
-| `verifyConditions` | Verify the presence of the `GH_TOKEN` set via [environment variables](#environment-variables). |
+| `verifyConditions` | Verify the configuration. |
 | `publish`          | Pushes commit to the [documentation branch](#options) |
 
 ## Install
@@ -68,7 +68,7 @@ or even shorter if default settings are used:
 
 | Variable                     | Description                                               |
 |------------------------------|-----------------------------------------------------------|
-| `GH_TOKEN` or `GITHUB_TOKEN` | **Required.** The token used to authenticate with GitHub. |
+| `GH_TOKEN` or `GITHUB_TOKEN` | **Optional.** The token used to authenticate with GitHub. |
 
 ### Options
 

--- a/src/main/ts/index.ts
+++ b/src/main/ts/index.ts
@@ -17,7 +17,7 @@ let _config: any
 export const verifyConditions = async (pluginConfig: any, context: TContext) => {
   const { logger } = context
   const config = await resolveConfig(pluginConfig, context, undefined, 'publish')
-  const { token, repo, src, ciBranch, docsBranch } = config
+  const { repo, src, ciBranch, docsBranch } = config
 
   if (!docsBranch) {
     logger.log(`gh-pages [skipped]: 'docsBranch' is empty for ${ciBranch}`)
@@ -25,11 +25,6 @@ export const verifyConditions = async (pluginConfig: any, context: TContext) => 
   }
 
   logger.log('verify gh-pages config')
-
-
-  if (!token) {
-    throw new AggregateError(['env.GH_TOKEN is required by gh-pages plugin'])
-  }
 
   if (!repo) {
     throw new AggregateError(['package.json repository.url does not match github.com pattern'])

--- a/src/test/ts/index.ts
+++ b/src/test/ts/index.ts
@@ -1,5 +1,4 @@
 import { ICallable } from '@qiwi/substrate-types'
-import AggregateError from 'aggregate-error'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -92,22 +91,6 @@ describe('index', () => {
         pullTagsBranch: DEFAULT_PULL_TAGS_BRANCH
       })
       expect(result).toBeUndefined()
-    })
-
-    it('asserts GH_TOKEN', async () => {
-      const { verifyConditions } = require('../../main/ts')
-      const context = {
-        logger,
-        options: {
-          ...globalConfig,
-          [step]: [{ path }]
-        },
-        cwd,
-        env: { GITHUB_TOKEN: undefined }
-      }
-
-      await expect(verifyConditions(pluginConfig, context))
-        .rejects.toEqual(new AggregateError(['env.GH_TOKEN is required by gh-pages plugin']))
     })
 
     describe('repo check', () => {


### PR DESCRIPTION
Remove the requirement for GH_TOKEN in the gh-pages plugin configuration, allowing it to be optional. Update related documentation and tests accordingly.