### PR TITLE
Add GH_TOKEN to CI environment variables for zx-semrel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_PROVENANCE: true
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm_config_yes=true npx zx-semrel
 
   pr:


### PR DESCRIPTION
Include the `GH_TOKEN` in the CI environment to enable authentication for the zx-semrel tool.